### PR TITLE
Initial work for the OrderQueue

### DIFF
--- a/config/atlas.cfg
+++ b/config/atlas.cfg
@@ -1,9 +1,9 @@
 # material, source, x,y, width, height
-# diamond, res://art/materials.png, 0,0, 29, 24
-# gold, res://art/materials.png, 30,0, 31, 22
-# bronze, res://art/materials.png, 60,0, 28,27
-# leather, res://art/materials.png, 88,0, 32,28
-# wood, res://art/materials.png, 120,0, 28, 28
+#diamond, res://art/materials.png, 0,0, 29, 24
+#gold, res://art/materials.png, 30,0, 31, 22
+#bronze, res://art/materials.png, 60,0, 28,27
+#leather, res://art/materials.png, 88,0, 32,28
+#wood, res://art/materials.png, 120,0, 28, 28
 # b_staff, res://art/items.png, 0, 0, 4, 28
 # b_shield, res://art/items.png, 4, 0, 24, 26
 # b_sword, res://art/items.png, 28, 0, 16, 28
@@ -15,9 +15,8 @@ gold_sword, res://art/small_items.png, 0, 31, 24, 12
 diamond_staff, res://art/small_items.png, 32, 0, 24, 12
 bronze_staff, res://art/small_items.png, 32, 14, 24, 12
 gold_staff, res://art/small_items.png, 32, 31, 24, 12
-diamond, res://art/small_items.png, 66, 5, 8, 5
-bronze, res://art/small_items.png, 66, 18, 9, 8
-gold, res://art/small_items.png, 66, 36, 8, 6
-wood, res://art/small_items.png, 82, 5, 7, 8
-leather, res://art/small_items.png, 82, 17, 10, 9
-
+ diamond, res://art/small_items.png, 66, 5, 8, 5
+ bronze, res://art/small_items.png, 66, 18, 9, 8
+ gold, res://art/small_items.png, 66, 36, 8, 6
+ wood, res://art/small_items.png, 82, 5, 7, 8
+ leather, res://art/small_items.png, 82, 17, 10, 9

--- a/config/objects.cfg
+++ b/config/objects.cfg
@@ -1,6 +1,6 @@
 # item, part_a, part_b, allowed_time_ms, base_point_value
 # b_sword,bronze,leather,5000,150
 # b_shield,bronze,bronze,5000, 150
-bronze_sword, leather, bronze, 3500, 150
-diamond_sword, leather, diamond, 3500, 150
-gold_sword, leather, gold, 3500, 150
+bronze_sword, leather, bronze, 5000, 150
+diamond_sword, leather, diamond, 5000, 150
+gold_sword, leather, gold, 7000, 150

--- a/nodes/ui/CowndownTimer.gd
+++ b/nodes/ui/CowndownTimer.gd
@@ -43,8 +43,7 @@ var paused_time_ms: int = 0
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	if run_time == 0:
-		run_time = 4
+	assert(run_time > 0)
 
 	run_time_ms = run_time * 1000
 	timer.one_shot = true
@@ -101,6 +100,7 @@ func _draw():
 	var draw_center = Vector2.ZERO
 	var now: float = Time.get_ticks_msec()
 	var progress: float = (now - start_time_ms - paused_time_ms) / run_time_ms
+	progress = clampf(progress, 0, 1)
 
 	match display_type:
 		'wheel':
@@ -139,8 +139,8 @@ func pause() -> void:
 	redraw_timer.set_paused(true)
 
 func _on_timer_timeout():
+	redraw_timer.set_paused(true)
 	timeout.emit(id)
-	queue_free()
 
 func _on_redraw_timer_timeout():
 	queue_redraw()

--- a/nodes/ui/HUD.gd
+++ b/nodes/ui/HUD.gd
@@ -20,7 +20,6 @@ func _ready():
 	add_child(p)
 
 	Jukebox.play_bg()
-	pass
 
 func _exit_tree():
 	remove_child(Jukebox.get_player())
@@ -39,3 +38,19 @@ func _background_pressed():
 
 func _title_pressed():
 	Jukebox.play_title()
+
+func _on_button_pressed():
+	var item = $OrderQueue.queue[0]
+	$OrderQueue.remove_item(item.id)
+
+func _on_button_2_pressed():
+	var item = $OrderQueue.queue[1]
+	$OrderQueue.remove_item(item.id)
+
+func _on_button_3_pressed():
+	var item = $OrderQueue.queue[2]
+	$OrderQueue.remove_item(item.id)
+
+func _on_button_4_pressed():
+	var wb = WantBubbleFactory.new_item(null)
+	$OrderQueue.add_item(wb)

--- a/nodes/ui/HUD.tscn
+++ b/nodes/ui/HUD.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=3 uid="uid://bty8lytcdurqn"]
+[gd_scene load_steps=7 format=3 uid="uid://bty8lytcdurqn"]
 
 [ext_resource type="Script" path="res://nodes/ui/HUD.gd" id="1_1uwmk"]
 [ext_resource type="PackedScene" uid="uid://um802b47lglk" path="res://nodes/ui/ScoreDisplay.tscn" id="1_fnd5s"]
 [ext_resource type="PackedScene" uid="uid://btoot08xfykph" path="res://nodes/ui/TimeDisplay.tscn" id="3_kfrte"]
 [ext_resource type="Texture2D" uid="uid://cgg43vy8g6btt" path="res://art/trash-bg.png" id="4_0sk3r"]
 [ext_resource type="Texture2D" uid="uid://jl5yea5dkm0y" path="res://art/audio-64.png" id="4_sc0ny"]
+[ext_resource type="PackedScene" uid="uid://c6dlko1xek8xl" path="res://nodes/ui/OrderQueue.tscn" id="6_6kiyj"]
 
 [node name="Hud" type="CanvasLayer"]
 script = ExtResource("1_1uwmk")
@@ -44,4 +45,43 @@ icon = ExtResource("4_sc0ny")
 flat = true
 icon_alignment = 1
 
+[node name="OrderQueue" parent="." instance=ExtResource("6_6kiyj")]
+position = Vector2(523, 627)
+
+[node name="Button" type="Button" parent="."]
+visible = false
+offset_left = 508.0
+offset_top = 486.0
+offset_right = 550.0
+offset_bottom = 536.0
+text = "1"
+
+[node name="Button2" type="Button" parent="."]
+visible = false
+offset_left = 585.0
+offset_top = 487.0
+offset_right = 627.0
+offset_bottom = 534.0
+text = "2"
+
+[node name="Button3" type="Button" parent="."]
+visible = false
+offset_left = 669.0
+offset_top = 488.0
+offset_right = 704.0
+offset_bottom = 533.0
+text = "3"
+
+[node name="Button4" type="Button" parent="."]
+visible = false
+offset_left = 575.0
+offset_top = 409.0
+offset_right = 628.0
+offset_bottom = 447.0
+text = "Add"
+
 [connection signal="toggled" from="Trash-bg/AudioToggle" to="." method="_toggle_audio"]
+[connection signal="pressed" from="Button" to="." method="_on_button_pressed"]
+[connection signal="pressed" from="Button2" to="." method="_on_button_2_pressed"]
+[connection signal="pressed" from="Button3" to="." method="_on_button_3_pressed"]
+[connection signal="pressed" from="Button4" to="." method="_on_button_4_pressed"]

--- a/nodes/ui/OrderQueue.gd
+++ b/nodes/ui/OrderQueue.gd
@@ -1,0 +1,83 @@
+extends Node2D
+
+# Array<WantBubble>
+var queue = []
+
+func get_size() -> int:
+	return queue.size()
+
+func get_item(id: String):
+	var idx = 0
+	for e in queue:
+		if e.id == id:
+			return idx
+		idx += 1
+	return null
+
+# returns ?WantBubble
+func remove_item(id: String):
+	print('removing: ' + id)
+	if queue.size() == 0:
+		return
+
+	var idx = get_item(id)
+	print('found at idx: ', idx)
+	if idx == null:
+		return
+	idx = idx as int # for the type checker
+	var tgt = queue[idx]
+	queue[idx] = null
+
+	# can't remove yet in case we want to do any tweening
+	_reflow(idx, tgt)
+	
+	return tgt
+
+func add_item(wb: WantBubble):
+	wb.auto_free = false
+	queue.push_back(wb)
+	print('queue is now: ')
+	for e in queue:
+		print(e.id)
+	print('')
+
+	add_child(wb)
+	wb.timeout.connect(_item_timeout)
+	wb.completed.connect(_item_filled)
+	_reflow(queue.size() - 1, wb)
+
+func _item_timeout(id: String):
+	remove_item(id)
+
+func _item_filled(id: String, _points: int, _remaining_ms: int):
+	remove_item(id)
+
+func _get_coords_pos(idx: int) -> Vector2:
+	return Vector2(idx * 74, 0)
+
+func _reflow(idx: int, tgt: WantBubble):
+	if queue[idx] == null:
+		# remove the null place holder
+		queue.remove_at(idx)
+		# we may want to tween eventually but for now remove the child / free it
+		remove_child(tgt)
+		tgt.queue_free()
+		print('Updated queue:')
+		for n in range(0, queue.size()):
+			print(queue[n].id)
+			var p = _get_coords_pos(n)
+			queue[n].position = Vector2(p.x, p.y)
+		print('')
+	else:
+		var p = _get_coords_pos(idx)
+		tgt.position = Vector2(p.x, p.y)
+		#tgt.transform = Transform2D() # _get_coords_pos(idx)
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass

--- a/nodes/ui/OrderQueue.tscn
+++ b/nodes/ui/OrderQueue.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=2 format=3 uid="uid://c6dlko1xek8xl"]
+
+[ext_resource type="Script" path="res://nodes/ui/OrderQueue.gd" id="1_8u5ah"]
+
+[node name="OrderQueue" type="Node2D"]
+script = ExtResource("1_8u5ah")
+
+[node name="SlotA" type="Marker2D" parent="."]
+
+[node name="Button" type="Button" parent="SlotA"]
+visible = false
+offset_right = 64.0
+offset_bottom = 64.0
+
+[node name="SlotB" type="Marker2D" parent="."]
+position = Vector2(80, 0)
+
+[node name="Button" type="Button" parent="SlotB"]
+visible = false
+offset_right = 64.0
+offset_bottom = 64.0
+metadata/_edit_use_anchors_ = true
+
+[node name="SlotC" type="Marker2D" parent="."]
+position = Vector2(160, 0)
+
+[node name="Button" type="Button" parent="SlotC"]
+visible = false
+offset_right = 64.0
+offset_bottom = 64.0
+metadata/_edit_use_anchors_ = true

--- a/nodes/ui/WantBubble.gd
+++ b/nodes/ui/WantBubble.gd
@@ -20,17 +20,24 @@ signal completed
 
 @export var display_timer: bool = true
 
+# free the bubble after it times out or gets filled
+@export var auto_free: bool = true
+
 # what are we building
 @export var item_tex: Texture2D
 @export var part_a_tex: Texture2D
 @export var part_b_tex: Texture2D
+
+func set_complete_time_ms(time_ms: int) -> void:
+	complete_time_ms = time_ms
+	$CompletionTimer.run_time_sec = time_ms / 1000.0
+	$CountdownTimer.run_time = time_ms / 1000.0
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	$Frame/Item.texture = item_tex
 	$Frame/PartA.texture = part_a_tex
 	$Frame/PartB.texture = part_b_tex
-	$CompletionTimer.run_time_sec = complete_time_ms / 1000.0
 
 func is_paused() -> bool:
 	return $CompletionTimer.is_paused()
@@ -48,9 +55,13 @@ func _get_configuration_warning() -> String:
 	return ""
 
 func _on_completion_timer_timeout():
+	$CompletionTimer.pause()
+	$CountdownTimer.pause()
 	timeout.emit(id)
-	queue_free()
+	if auto_free:
+		queue_free()
 
 func fill() -> void:
 	completed.emit(id, point_value, $CompletionTimer.remaining_time_ms())
-	queue_free()
+	if auto_free:
+		queue_free()

--- a/scripts/WantBubbleFactory.gd
+++ b/scripts/WantBubbleFactory.gd
@@ -113,7 +113,7 @@ func get_tex(tex_name: String):
 	tex.set_region(rect)
 	return tex
 
-# returns a new WantBubble Node, as configured in config does not have an ID set
+# returns a new WantBubble Node, as configured in config; has random ID set
 # TODO: is it possible to make variadic functions in gdscript
 func new_item(opts) -> WantBubble:
 	_load_cfg()
@@ -139,10 +139,20 @@ func new_item(opts) -> WantBubble:
 	wb.part_a_tex = get_tex(parts[0])
 	wb.part_b_tex = get_tex(parts[1])
 
-	wb.complete_time_ms = get_object_time_ms(tgt)
+	wb.set_complete_time_ms(get_object_time_ms(tgt))
 	wb.point_value = get_object_points(tgt)
 
+	wb.id = tgt + '-' + generate_word(10)
+
 	return wb
+
+var _characters = 'abcdefghijklmnopqrstuvwxyz0123456789'
+func generate_word(length):
+	var word: String
+	var n_char = len(_characters)
+	for i in range(length):
+		word += _characters[randi() % n_char]
+	return word
 
 # get all defined items
 func get_items() -> Array:


### PR DESCRIPTION
extremely v0 of order queue, I'm going to merge because it shouldn't break anything too much:

I added an assert to the countdown timer to ensure that we explicitly set the runtime.

```
 # Called when the node enters the scene tree for the first time.
 func _ready():
-    if run_time == 0:
-        run_time = 4
+    assert(run_time > 0)
```

I think I might've seen you using it, if so you just need to set run_time.

I also disabled having it automatically queue_free bc it was causing problems so you will need to connect to the timeout signal and handle that. alternatively you could add auto_free as a configurable option and gate queue_free under that

```
 func _on_timer_timeout():
+    redraw_timer.set_paused(true)
     timeout.emit(id)
-    queue_free()
```